### PR TITLE
Add missing err:out_of_range code-sections + intent fixes

### DIFF
--- a/bt_editor/sidepanel_monitor.cpp
+++ b/bt_editor/sidepanel_monitor.cpp
@@ -49,58 +49,58 @@ void SidepanelMonitor::on_timer()
             const uint32_t header_size = flatbuffers::ReadScalar<uint32_t>( buffer );
             const uint32_t num_transitions = flatbuffers::ReadScalar<uint32_t>( &buffer[4+header_size] );
 
-	    // check uid in the index, if failed load tree from server
-	    try {
-		for(size_t offset = 4; offset < header_size +4; offset +=3 )
-		{
-		    const uint16_t uid = flatbuffers::ReadScalar<uint16_t>(&buffer[offset]);
-		    _uid_to_index.at(uid);
-		}
-	    
-		for(size_t t=0; t < num_transitions; t++)
-		{
-		    size_t offset = 8 + header_size + 12*t;
-		    const uint16_t uid = flatbuffers::ReadScalar<uint16_t>(&buffer[offset+8]);
-		    _uid_to_index.at(uid);
-		}
-	    }
-	    catch( std::out_of_range& err) {
-		qDebug() << "Reload tree from server";
-		if( !getTreeFromServer() ) {
-		    _connected = false;
-		    ui->lineEdit->setDisabled(false);
-		    _timer->stop();
-		    connectionUpdate(false);
-		    return;
-		}
-	    }
-
-            for(size_t offset = 4; offset < header_size +4; offset +=3 )
-            {
-                const uint16_t uid = flatbuffers::ReadScalar<uint16_t>(&buffer[offset]);
-                const uint16_t index = _uid_to_index.at(uid);
-                AbstractTreeNode* node = _loaded_tree.node( index );
-                node->status = convert(flatbuffers::ReadScalar<Serialization::NodeStatus>(&buffer[offset+2] ));
-            }
-
             std::vector<std::pair<int, NodeStatus>> node_status;
 
-            //qDebug() << "--------";
-            for(size_t t=0; t < num_transitions; t++)
-            {
-                size_t offset = 8 + header_size + 12*t;
+	    // check uid in the index, if failed load tree from server
+            try {
+                for(size_t offset = 4; offset < header_size +4; offset +=3 )
+                {
+                    const uint16_t uid = flatbuffers::ReadScalar<uint16_t>(&buffer[offset]);
+                    _uid_to_index.at(uid);
+                }
+                
+                for(size_t t=0; t < num_transitions; t++)
+                {
+                    size_t offset = 8 + header_size + 12*t;
+                    const uint16_t uid = flatbuffers::ReadScalar<uint16_t>(&buffer[offset+8]);
+                    _uid_to_index.at(uid);
+                }
+                for(size_t offset = 4; offset < header_size +4; offset +=3 )
+                {
+                    const uint16_t uid = flatbuffers::ReadScalar<uint16_t>(&buffer[offset]);
+                    const uint16_t index = _uid_to_index.at(uid);
+                    AbstractTreeNode* node = _loaded_tree.node( index );
+                    node->status = convert(flatbuffers::ReadScalar<Serialization::NodeStatus>(&buffer[offset+2] ));
+                }
+                
 
-                // const double t_sec  = flatbuffers::ReadScalar<uint32_t>( &buffer[offset] );
-                // const double t_usec = flatbuffers::ReadScalar<uint32_t>( &buffer[offset+4] );
-                // double timestamp = t_sec + t_usec* 0.000001;
-                const uint16_t uid = flatbuffers::ReadScalar<uint16_t>(&buffer[offset+8]);
-                const uint16_t index = _uid_to_index.at(uid);
-                // NodeStatus prev_status = convert(flatbuffers::ReadScalar<Serialization::NodeStatus>(&buffer[index+10] ));
-                NodeStatus status  = convert(flatbuffers::ReadScalar<Serialization::NodeStatus>(&buffer[offset+11] ));
+                //qDebug() << "--------";
+                for(size_t t=0; t < num_transitions; t++)
+                {
+                    size_t offset = 8 + header_size + 12*t;
 
-                _loaded_tree.node(index)->status = status;
-                node_status.push_back( {index, status} );
+                    // const double t_sec  = flatbuffers::ReadScalar<uint32_t>( &buffer[offset] );
+                    // const double t_usec = flatbuffers::ReadScalar<uint32_t>( &buffer[offset+4] );
+                    // double timestamp = t_sec + t_usec* 0.000001;
+                    const uint16_t uid = flatbuffers::ReadScalar<uint16_t>(&buffer[offset+8]);
+                    const uint16_t index = _uid_to_index.at(uid);
+                    // NodeStatus prev_status = convert(flatbuffers::ReadScalar<Serialization::NodeStatus>(&buffer[index+10] ));
+                    NodeStatus status  = convert(flatbuffers::ReadScalar<Serialization::NodeStatus>(&buffer[offset+11] ));
 
+                    _loaded_tree.node(index)->status = status;
+                    node_status.push_back( {index, status} );
+
+                }
+            }
+            catch( std::out_of_range& err) {
+                qDebug() << "Reload tree from server";
+                if( !getTreeFromServer() ) {
+                    _connected = false;
+                    ui->lineEdit->setDisabled(false);
+                    _timer->stop();
+                    connectionUpdate(false);
+                    return;
+                }
             }
             // update the graphic part
             emit changeNodeStyle( "BehaviorTree", node_status );


### PR DESCRIPTION
Hi there,

I was able to test your PR against my PR of adding Groot Monitoring to Nav2: https://github.com/ros-planning/navigation2/pull/1958

Your PR helped dealing with everything related reloading the Tree on Groot side IF the (ZMQ) connection between Nav2/status publisher and Groot stays OPEN. (Great work, thanks!!)

But, when you disconnect Groot and build a new tree (nav2 = reset lifecycle node) so that the tree gets a new UID, then it still fails. So I "just" grabbed all the remaining code with references to the UID and placed it inside the Try/catch.

Worked like a charm. Also did some small intend fixed (tabs).

Please accept this PR in the pure hope that this will be added to your existing PR: https://github.com/BehaviorTree/Groot/pull/61

Cheers from Germany :beers:  